### PR TITLE
Changed moduleId from using module.id to __filename

### DIFF
--- a/development/src/ng2-google-recaptcha/create-recaptcha/create-recaptcha.component.ts
+++ b/development/src/ng2-google-recaptcha/create-recaptcha/create-recaptcha.component.ts
@@ -7,7 +7,7 @@ import { RenderRecaptchaDirective } from '../render-recaptcha/render-recaptcha.d
 //
 @Component({
 
-    moduleId: module.id,
+    moduleId: __filename,
     selector: 'ng2-google-recaptcha',
 
     template: `<div id="{{recaptchaId}}" ng2GoogleRecaptchaRender (onCaptchaComplete)="onCaptchaCompleted($event)"


### PR DESCRIPTION
When using this module, webpack complained about module.id.
Changed to __filename.

throw new Error(("moduleId should be a string in \"" + __webpack_require__.i(__WEBPACK_IMPORTED_MODULE_4__facade_lang__["i" /* stringify */])(type) + "\". See https://goo.gl/wIDDiL for more information.\n") +
        ^

Error: moduleId should be a string in "CreateRecaptchaComponent". See https://goo.gl/wIDDiL for more information.