### PR TITLE
removing module.id

### DIFF
--- a/development/src/ng2-google-recaptcha/create-recaptcha/create-recaptcha.component.ts
+++ b/development/src/ng2-google-recaptcha/create-recaptcha/create-recaptcha.component.ts
@@ -7,7 +7,6 @@ import { RenderRecaptchaDirective } from '../render-recaptcha/render-recaptcha.d
 //
 @Component({
 
-    moduleId: module.id,
     selector: 'ng2-google-recaptcha',
 
     template: `<div id="{{recaptchaId}}" ng2GoogleRecaptchaRender (onCaptchaComplete)="onCaptchaCompleted($event)"


### PR DESCRIPTION
I removed the module.id because it causes an error when we use webpack to build angular applications