### PR TITLE
Fix Error when generating an AOT prod build using angularcli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ samples/typings
 samples/src/**/*.js.map
 samples/src/**/*.js
 samples/src/**/*.d.ts
+.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/development/src/ng2-google-recaptcha/create-recaptcha/create-recaptcha.component.ts
+++ b/development/src/ng2-google-recaptcha/create-recaptcha/create-recaptcha.component.ts
@@ -29,7 +29,7 @@ export class CreateRecaptchaComponent implements OnInit {
     @Input('recaptchaId') recaptchaId: string = 'grecaptcha';
 
     @ViewChild(RenderRecaptchaDirective)
-    private recaptchaInstance: RenderRecaptchaDirective;
+    public recaptchaInstance: RenderRecaptchaDirective;
 
     //
     // Called to initialise the object
@@ -52,7 +52,7 @@ export class CreateRecaptchaComponent implements OnInit {
     // Called when the Captcha has finished
     //
     /* tslint:disable:no-unused-variable */
-    private onCaptchaCompleted(data: string) {
+    public onCaptchaCompleted(data: string) {
         /* tslint:enable:no-unused-variable */
 
         // Pass through whether we succeeded or not


### PR DESCRIPTION
when building an angular project in angular-cli using "ng build --prod --aot", an error occurs. See error message below:

ERROR in /$$_gendir/node_modules/ng2-google-recaptcha/create-recaptcha/create-recaptcha.component.ngfactory.ts (139,18): Property 'recaptchaInstance' is private and only accessible within class 'CreateRecaptchaComponent'.


This error occurs as a result of the property "recaptchaInstance" being used in a template but is declared as a private member in the component. To build successfully using --aot, we must ensure that variables used in template must be declared as public in the component.

This fix solves the problem.